### PR TITLE
__all__ to reduce number objects

### DIFF
--- a/pynsee/download/__init__.py
+++ b/pynsee/download/__init__.py
@@ -14,6 +14,8 @@ import requests
 from tqdm import tqdm
 from tqdm.utils import CallbackIOWrapper
 
+__all__ = ["check_year_available", "load_data", "download_store_file"]
+
 # READ ALL DATA SOURCES AVAILABLE USING JSON ONLINE FILE ----------------
 
 URL_DATA_LIST = "https://raw.githubusercontent.com/" + \

--- a/tests/download/test_pyinsee_download.py
+++ b/tests/download/test_pyinsee_download.py
@@ -1,10 +1,18 @@
 import unittest
-
+import warnings
 import os.path
 import hashlib
 import pandas as pd
 
 from pynsee.download import *
+from pynsee.download import info_data
+from pynsee.download import telechargerDonnees
+from pynsee.download import load_data
+from pynsee.download import check_year_available
+from pynsee.download import dict_data_source
+from pynsee.download import millesimesDisponibles
+from pynsee.download import telechargerFichier
+
 
 class MyTests(unittest.TestCase):
 


### PR DESCRIPTION
Only 3 pieces exported in `download` subpackage : 

> ```python
> __all__ = ["check_year_available", "load_data", "download_store_file"]è
> ```

Indeed, the workspace is cleaner

```python
>>> from pynsee.download import *
>>> globals()
{'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <class '_frozen_importlib.BuiltinImporter'>, '__spec__': None, '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, 'check_year_available': <function check_year_available at 0x7fea83c95e10>, 'load_data': <function load_data at 0x7fea83c95990>, 'download_store_file': <function download_store_file at 0x7fea83c95bd0>}
```

- close #83 