### PR TITLE
Support range patterns of SIRENE API

### DIFF
--- a/pynsee/sirene/search_sirene.py
+++ b/pynsee/sirene/search_sirene.py
@@ -177,8 +177,18 @@ def search_sirene(
         else:
             phntc_string = ".phonetisation"
 
-        # if pattern has several words, split and put mutiple conditions with OR
-        patt = re.sub(r"\s+", "|", patt)
+        # if pattern has several words, split and put mutiple conditions
+        # using OR, unless it's a range condition, cf.
+        # https://www.sirene.fr/static-resources/htm/sommaire.html
+        if not (
+            re.match(r"\[\w+\s+TO\s+\w+\]", patt) or
+            re.match(r"\{\w+\s+TO\s+\w+\}", patt)
+        ):
+            patt = re.sub(r"\s+", "|", patt)
+        else:
+            # only single spaces are accepted in ranges
+            patt = re.sub(r"\s+", " ", patt)
+
         list_patt = patt.split("|")
 
         list_var_patt = []


### PR DESCRIPTION
Fixes #165 by supporting the ``[X TO Y]`` and ``{X TO Y}`` patterns (cf. [doc](https://www.sirene.fr/static-resources/htm/multi_plages.html)).

NB: I used ``\w`` for the pattern matching, not sure whether we need to support special characters, let me know if it should be something else, or even ``.``.