### PR TITLE
Move to parquet and platformdirs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,7 +16,7 @@ sphinxcontrib-svg2pdfconverter
 pandas>=0.24.2
 tqdm>=4.56.0
 requests>=2.25.1
-appdirs>=1.4.4
+platformdirs
 unidecode>=1.2.0
 datetime>=3.5.9
 pathlib2>=2.3.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,6 +14,7 @@ ipython>=7.16.1
 Jinja2>=3.0
 sphinxcontrib-svg2pdfconverter
 pandas>=0.24.2
+pyarrow
 tqdm>=4.56.0
 requests>=2.25.1
 platformdirs

--- a/pynsee/macrodata/_load_dataset_data.py
+++ b/pynsee/macrodata/_load_dataset_data.py
@@ -1,15 +1,19 @@
 import os
+
+import platformdirs
 import pandas as pd
 
 from pynsee.utils._create_insee_folder import _create_insee_folder
 from pynsee.utils._hash import _hash
 from pynsee.macrodata.get_dataset_list import get_dataset_list
 
+
 def _del_dataset_files():
     list_dataset_files = _get_dataset_files()
     if len(list_dataset_files) > 0:
         for f in list_dataset_files:
             os.remove(f)
+
 
 def _get_dataset_files():
     list_dataset = list(get_dataset_list().id.unique())
@@ -18,10 +22,12 @@ def _get_dataset_files():
     file_dataset_metadata_list_exist = [f for f in file_dataset_metadata_list if os.path.exists(f)]
     return file_dataset_metadata_list_exist
 
+
 def _load_dataset_data():
     list_dataset_files = _get_dataset_files()
-    if len(list_dataset_files) > 0:
-        return pd.concat([pd.read_pickle(f) for f in list_dataset_files])
-    else:
-        return None
 
+    if len(list_dataset_files) > 0:
+        data = pd.concat([pd.read_parquet(f) for f in list_dataset_files])
+        data.to_parquet(fname)
+        return data
+    return None

--- a/pynsee/macrodata/_load_dataset_data.py
+++ b/pynsee/macrodata/_load_dataset_data.py
@@ -1,6 +1,5 @@
 import os
 
-import platformdirs
 import pandas as pd
 
 from pynsee.utils._create_insee_folder import _create_insee_folder

--- a/pynsee/macrodata/_load_dataset_data.py
+++ b/pynsee/macrodata/_load_dataset_data.py
@@ -27,6 +27,5 @@ def _load_dataset_data():
 
     if len(list_dataset_files) > 0:
         data = pd.concat([pd.read_parquet(f) for f in list_dataset_files])
-        data.to_parquet(fname)
         return data
     return None

--- a/pynsee/utils/_clean_insee_folder.py
+++ b/pynsee/utils/_clean_insee_folder.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 # Copyright : INSEE, 2021
 
-import appdirs
 import os
+
+import platformdirs
 
 
 def _clean_insee_folder():
 
-    local_appdata_folder = appdirs.user_cache_dir()
-    insee_folder = local_appdata_folder + "/pynsee" + "/pynsee"
+    local_appdata_folder = platformdirs.user_cache_dir()
+    insee_folder = os.path.join(local_appdata_folder, "pynsee", "pynsee")
 
     # delete all files in the folder
     if os.path.exists(insee_folder):

--- a/pynsee/utils/_create_insee_folder.py
+++ b/pynsee/utils/_create_insee_folder.py
@@ -3,7 +3,7 @@
 
 from functools import lru_cache
 import os
-import appdirs
+import platformdirs
 
 from pynsee.utils._get_temp_dir import _get_temp_dir
 from pynsee.utils._hash import _hash
@@ -15,14 +15,14 @@ def _create_insee_folder():
     try:
 
         # find local folder
-        local_appdata_folder = appdirs.user_cache_dir()
-        insee_folder = local_appdata_folder + "/pynsee"
+        local_appdata_folder = platformdirs.user_cache_dir()
+        insee_folder = os.path.join(local_appdata_folder, "pynsee")
 
         # create insee folder
         if not os.path.exists(insee_folder):
             os.mkdir(insee_folder)
 
-        insee_folder = insee_folder + "/pynsee"
+        insee_folder = os.path.join(insee_folder, "pynsee")
 
         # create insee folder
         if not os.path.exists(insee_folder):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pandas>=0.24.2
+pyarrow
 tqdm>=4.56.0
 requests>=2.23
 platformdirs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas>=0.24.2
 tqdm>=4.56.0
 requests>=2.23
-appdirs>=1.4.4
+platformdirs
 unidecode>=1.1.0
 urllib3
 shapely>=1.8.0

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
     license_files=('LICENSE.md',),
     install_requires=[
             "pandas>=0.24.2",
+            "pyarrow",
             "tqdm>=4.56.0",
             "requests>=2.23",
             "platformdirs",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
             "pandas>=0.24.2",
             "tqdm>=4.56.0",
             "requests>=2.23",
-            "appdirs>=1.4.4",
+            "platformdirs",
             "unidecode>=1.1.0",
             "shapely>=1.8.0",
             "urllib3"],


### PR DESCRIPTION
Use parquet instead of pickle to store datasets (around 100 times faster), should be supported since pandas 0.21 and we require 0.24.

Move to platformdirs for cache folder, etc, as appdirs is unmaintained.