### PR TITLE
Fix sirene endpoint url

### DIFF
--- a/pynsee/sirene/_request_sirene.py
+++ b/pynsee/sirene/_request_sirene.py
@@ -29,7 +29,7 @@ def _request_sirene(query, kind, number=1001):
     else:
         raise ValueError("!!! kind should be among : siren siret !!!")
 
-    INSEE_api_sirene_siren = "https://api.insee.fr/entreprises/sirene3/V3.11"
+    INSEE_api_sirene_siren = "https://api.insee.fr/entreprises/sirene/V3.11"
     number_query_limit = 1000
 
     number_query = min(number_query_limit, number)


### PR DESCRIPTION
I think the endpoint `/sirene3/V3.11/` is retired. In fact, INSEE's api documentation does not mentions it. May be I'm not aware of the goal of the `/sirene3/V3.11/`

# Reproduction

## Works

`http https://api.insee.fr/entreprises/sirene/V3/siret\?q\=\(dateDernierTraitementEtablissement:\[2024-04-03T11:59%20TO%202024-04-04T11:59\]\)\&nombre\=1\&curseur\=\*`

## Does not work (503 error)

`https://api.insee.fr/entreprises/sirene3/V3.11/siret\?q\=\(dateDernierTraitementEtablissement:\[2024-04-03T11:59%20TO%202024-04-04T11:59\]\)\&nombre\=1\&curseur\=\*`
