### PR TITLE
Do not save_df if empty, save if forced update

### DIFF
--- a/pynsee/utils/save_df.py
+++ b/pynsee/utils/save_df.py
@@ -1,16 +1,19 @@
+import datetime
 import functools
-import os
-import pandas as pd
-import warnings
-import shapely
-from shapely.errors import ShapelyDeprecationWarning
-import warnings
-import datetime 
 import logging
-logger = logging.getLogger(__name__)
+import os
+import warnings
+
+from typing import Optional, Type
+
+import pandas as pd
 
 from pynsee.utils._create_insee_folder import _create_insee_folder
 from pynsee.utils._hash import _hash
+
+
+logger = logging.getLogger(__name__)
+
 
 @functools.lru_cache(maxsize=None)
 def _warning_cached_data(file, mdate=None, day_lapse=None):
@@ -29,15 +32,27 @@ def _warning_cached_data(file, mdate=None, day_lapse=None):
 
     logger.info(strg_print)
 
-def save_df(obj=pd.DataFrame, parquet=True, day_lapse_max=None):
+
+def save_df(
+    obj: Type[pd.DataFrame] = pd.DataFrame,
+    parquet: bool = True,
+    day_lapse_max: Optional[int] = None
+):
+    ''' Autosave object to reload from file unless it's empty '''
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            
             data_folder = _create_insee_folder()
-            string_file_arg = [str(kwargs[a]) for a in kwargs.keys() if a not in ['update', 'silent']]
-            string_file_arg += [func.__name__] + [str(a) for a in args]            
-            file_name = os.path.join(data_folder, _hash(''.join(string_file_arg)))
+
+            string_file_arg = [
+                str(kwargs[a]) for a in kwargs.keys()
+                if a not in ('update', 'silent')
+            ]
+
+            string_file_arg += [func.__name__] + [str(a) for a in args]
+
+            file_name = os.path.join(
+                data_folder, _hash(''.join(string_file_arg)))
             
             if parquet:
                 file_name += ".parquet"
@@ -61,55 +76,63 @@ def save_df(obj=pd.DataFrame, parquet=True, day_lapse_max=None):
                 if day_lapse_max is not None:
                     if day_lapse > day_lapse_max:
                         update = True                    
-            
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=ShapelyDeprecationWarning)
 
-                if (not os.path.exists(file_name)) or update:   
+            if (not os.path.exists(file_name)) or update:
+                df = func(*args, **kwargs)
 
-                    df = func(*args, **kwargs)                    
-                    try:
-                        if parquet:
-                            df.to_parquet(file_name)
-                        else:
-                            df.to_csv(file_name, index=False)
-                            
-                    except Exception as e:
-                        warnings.warn(str(e))
-                        warnings.warn(f'Error, file not saved:\n{file_name}\n{df}')
-                        warnings.warn('\n')
-                                        
-                    if not silent:
-                        logger.info(f"Data saved:\n{file_name}")
-
-                else:
-                    try:                        
-                        if parquet:
-                            df = pd.read_parquet(file_name)
-                        else:
-                            df = pd.read_pickle(file_name)
-                            
-                        if 'Unnamed: 0' in df.columns:
-                            del df['Unnamed: 0']
-                            
-                    except Exception as e:
-                        warnings.warn(str(e))
-                                                
-                        kwargs2 = kwargs
-                        kwargs2['update'] = True
-                        
-                        warnings.warn('!!! Unable to load data, function retriggered !!!')
-                        
-                        df = func(*args, **kwargs2)                         
+                _save_dataframe(df, file_name, parquet, silent)
+            else:
+                try:
+                    if parquet:
+                        df = pd.read_parquet(file_name)
                     else:
-                        if not silent:
-                            
-                            mdate = insee_date_time_now - datetime.timedelta(days=day_lapse)
-                            
-                            _warning_cached_data(file_name,
-                                                 mdate= mdate,
-                                                 day_lapse=day_lapse)
-            
-            return obj(df)  
+                        df = pd.read_pickle(file_name)
+
+                    if 'Unnamed: 0' in df.columns:
+                        del df['Unnamed: 0']
+                except Exception as e:
+                    warnings.warn(str(e))
+
+                    kwargs2 = kwargs
+                    kwargs2['update'] = True
+
+                    warnings.warn(
+                        "!!! Unable to load data, recalling function "
+                        "with `update` set to True !!!")
+
+                    df = func(*args, **kwargs2)
+
+                    _save_dataframe(df, file_name, parquet, silent)
+                else:
+                    if not silent:
+                        mdate = (
+                            insee_date_time_now -
+                            datetime.timedelta(days=day_lapse)
+                        )
+
+                        _warning_cached_data(
+                            file_name, mdate= mdate, day_lapse=day_lapse)
+
+            return obj(df)
         return wrapper
     return decorator
+
+
+def _save_dataframe(
+    df: pd.DataFrame,
+    file_name: str,
+    parquet: bool,
+    silent: bool
+) -> None:
+    try:
+        if not df.empty:
+            if parquet:
+                df.to_parquet(file_name)
+            else:
+                df.to_csv(file_name, index=False)
+    except Exception as e:
+        warnings.warn(str(e))
+        warnings.warn(f"Error, file not saved:\n{file_name}\n{df}\n")
+    else:
+        if not silent:
+            logger.info(f"Data saved:\n{file_name}")


### PR DESCRIPTION
I updated the ``save_df`` function to not save if the dataframe is empty and added the save in case of a forced update if there is an error loading the file.

I also removed the shapely deprecation warnings ignore because I think we better know about these and fix them than silence them. Other people can ignore them manually in the meantime.