### PR TITLE
Bugfix - use http proxy from env variables

### DIFF
--- a/pynsee/utils/_get_credentials.py
+++ b/pynsee/utils/_get_credentials.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_credentials() -> Dict[str, str]:
-    '''
+    """
     Try to load credentials.
 
     If the environment variables `insee_key` and `insee_secret` are set, use
@@ -24,19 +24,22 @@ def _get_credentials() -> Dict[str, str]:
 
     Returns a dict containing at least an "insee_key" and an "insee_secret"
     entry.
-    '''
+    """
     key_dict: Dict[str, str] = {}
 
     try:
         key_dict["insee_key"] = os.environ["insee_key"]
         key_dict["insee_secret"] = os.environ["insee_secret"]
+        key_dict["http_proxy"] = os.environ.get("http_proxy", "")
+        key_dict["http_proxy"] = os.environ.get("http_proxy", "")
 
         envir_var_used = True
     except KeyError:
         envir_var_used = False
 
         config_file = os.path.join(
-            user_config_dir("pynsee", ensure_exists=True), "config.json")
+            user_config_dir("pynsee", ensure_exists=True), "config.json"
+        )
 
         try:
             with open(config_file, "r") as f:

--- a/tests/utils/test_pynsee_utils.py
+++ b/tests/utils/test_pynsee_utils.py
@@ -20,7 +20,7 @@ test_SDMX = True
 
 
 class TestFunction(TestCase):
-    
+
     version = (sys.version_info[0] == 3) & (sys.version_info[1] == 9)
 
     if version:
@@ -29,8 +29,15 @@ class TestFunction(TestCase):
         def test_get_token(self, StartKeys=StartKeys):
             insee_key = StartKeys["insee_key"]
             insee_secret = StartKeys["insee_secret"]
+            http_proxy = StartKeys.get("http_proxy", "")
+            https_proxy = StartKeys.get("https_proxy", "")
 
-            init_conn(insee_key=insee_key, insee_secret=insee_secret)
+            init_conn(
+                insee_key=insee_key,
+                insee_secret=insee_secret,
+                http_proxy=http_proxy,
+                https_proxy=https_proxy,
+            )
 
             token = _get_token(insee_key, insee_secret)
             self.assertTrue((token is not None))
@@ -63,10 +70,19 @@ class TestFunction(TestCase):
                 test = results.status_code == 200
                 self.assertTrue(test)
 
-        def test_request_insee_3(self):
+        def test_request_insee_3(self, StartKeys=StartKeys):
             # token is none and sdmx query fails
+
+            http_proxy = StartKeys.get("http_proxy", "")
+            https_proxy = StartKeys.get("https_proxy", "")
+
             def init_conn_foo():
-                init_conn(insee_key="test", insee_secret="test")
+                init_conn(
+                    insee_key="test",
+                    insee_secret="test",
+                    http_proxy=http_proxy,
+                    https_proxy=https_proxy,
+                )
 
             self.assertRaises(ValueError, init_conn_foo)
 
@@ -83,6 +99,18 @@ class TestFunction(TestCase):
                 _request_insee(sdmx_url=sdmx_url, api_url=api_url)
 
             self.assertRaises(ValueError, request_insee_test)
+
+            # Finally reset credentials : if test are run on any machine except
+            # github's workflows', you will want to keep the valid ceredentials
+            # in the csv storage (for next run of tests, for instance)
+            insee_key = StartKeys["insee_key"]
+            insee_secret = StartKeys["insee_secret"]
+            init_conn(
+                insee_key=insee_key,
+                insee_secret=insee_secret,
+                http_proxy=http_proxy,
+                https_proxy=https_proxy,
+            )
 
         def test_request_insee_4(self):
             # token is none and sdmx query is None


### PR DESCRIPTION
Small PR to :
* handle corporate proxies when pynsee connection is managed through os environment variables;
* use proxies during tests ran on a local machine;
* restore both proxies and credentials after tests are run on a local machine (if keys where stored on disk).