### PR TITLE
Fix mismatched exception types

### DIFF
--- a/pynsee/localdata/_get_geo_relation.py
+++ b/pynsee/localdata/_get_geo_relation.py
@@ -13,19 +13,55 @@ from pynsee.utils._get_temp_dir import _get_temp_dir
 
 @lru_cache(maxsize=None)
 def _get_geo_relation(geo, code, relation, date=None, type=None):
+    """
+    Get a relations to a territory, given a relation type using INSEE's API.
 
-    # relation_list = ['ascendants', 'descendants', 'suivants', 'precedents', 'projetes']
-    # list_available_geo = ['communes', 'regions', 'departements',
-    #                       'arrondissements', 'arrondissementsMunicipaux']
-    # code = '11'
-    # geo = 'region'
-    # relation = 'descendants'
+    As this function uses _request_insee under the hood, might trigger a
+    ValueError when the credentials are valid or if the query is not valid in
+    the first place.
 
-    # idf = _get_geo_relation('region', "11", 'descendants')
-    # essonne = _get_geo_relation('region', "11", 'ascendants')
+    Parameters
+    ----------
+    geo : str
+        The territory's type we're searching a georelation from.
+        Any of ['communes', 'regions', 'departements', 'arrondissements',
+        'arrondissementsMunicipaux']
+    code : str
+        The territory's code we're searching a georelation from.
+    relation : str
+        Type of desired relation.
+        Any of ['ascendants', 'descendants', 'suivants', 'precedents',
+        'projetes']
+    date : str, optional
+        Date of the relation. The default is None.
+    type : str, optional
+        Desired type of territories we're trying to find. The default is None.
+
+    Returns
+    -------
+    df_relation_all : pd.DataFrame
+        All territories matching the desired relation
+
+    Examples
+    -------
+    >>> from pynsee.localdata._get_geo_relation import _get_geo_relation
+    >>> idf_descendants = _get_geo_relation('region', "11", 'descendants')
+    >>> idf = _get_geo_relation("departement", "91", "ascendants")
+    >>> idf_deps = _get_geo_relation(
+            'region',
+            "11",
+            'descendants',
+            type="departement"
+            )
+    """
 
     api_url = (
-        "https://api.insee.fr/metadonnees/V1/geo/" + geo + "/" + code + "/" + relation
+        "https://api.insee.fr/metadonnees/V1/geo/"
+        + geo
+        + "/"
+        + code
+        + "/"
+        + relation
     )
 
     parameters = ["date", "type"]

--- a/pynsee/localdata/get_geo_list.py
+++ b/pynsee/localdata/get_geo_list.py
@@ -1,17 +1,16 @@
 # -*- coding: utf-8 -*-
 # Copyright : INSEE, 2021
 
-import os
 import pandas as pd
 from tqdm import trange
 import numpy as np
-from requests.exceptions import RequestException
 
 from pynsee.utils._paste import _paste
 from pynsee.localdata._get_geo_relation import _get_geo_relation
 from pynsee.localdata._get_geo_list_simple import _get_geo_list_simple
 
 from pynsee.utils.save_df import save_df
+
 
 @save_df(day_lapse_max=90)
 def get_geo_list(geo=None, date=None, update=False, silent=False):
@@ -94,7 +93,7 @@ def get_geo_list(geo=None, date=None, update=False, silent=False):
                     date=date,
                     type=type_geo,
                 )
-            except RequestException:
+            except ValueError:
                 df = _get_geo_relation(
                     geo="region",
                     code=list_reg[r],
@@ -179,16 +178,12 @@ def get_geo_list(geo=None, date=None, update=False, silent=False):
 
             for i in range(len(data_all.index)):
                 if pd.isna(data_all.loc[i, "TITLE_DEP1"]):
-                    data_all.loc[i, "CODE_DEP"] = data_all.loc[
-                        i, "code_dep2"
-                    ]
+                    data_all.loc[i, "CODE_DEP"] = data_all.loc[i, "code_dep2"]
                     data_all.loc[i, "TITLE_DEP"] = data_all.loc[
                         i, "TITLE_DEP2"
                     ]
                 else:
-                    data_all.loc[i, "CODE_DEP"] = data_all.loc[
-                        i, "code_dep1"
-                    ]
+                    data_all.loc[i, "CODE_DEP"] = data_all.loc[i, "code_dep1"]
                     data_all.loc[i, "TITLE_DEP"] = data_all.loc[
                         i, "TITLE_DEP1"
                     ]

--- a/pynsee/localdata/get_geo_list.py
+++ b/pynsee/localdata/get_geo_list.py
@@ -94,6 +94,7 @@ def get_geo_list(geo=None, date=None, update=False, silent=False):
                     type=type_geo,
                 )
             except ValueError:
+                # might be triggered by _request_insee while querying the API
                 df = _get_geo_relation(
                     geo="region",
                     code=list_reg[r],

--- a/pynsee/utils/_request_insee.py
+++ b/pynsee/utils/_request_insee.py
@@ -8,7 +8,11 @@ import time
 
 from pynsee.utils._get_token import _get_token
 from pynsee.utils._get_credentials import _get_credentials
-from pynsee.utils.requests_params import _get_requests_session, _get_requests_headers, _get_requests_proxies
+from pynsee.utils.requests_params import (
+    _get_requests_session,
+    _get_requests_headers,
+    _get_requests_proxies,
+)
 
 import logging
 
@@ -53,7 +57,7 @@ def _request_insee(
             print(api_url)
     except:
         pass
-        
+
     # force sdmx use with a system variable
     try:
         pynsee_use_sdmx = os.environ["pynsee_use_sdmx"]
@@ -80,11 +84,11 @@ def _request_insee(
 
         if token is not None:
             user_agent = _get_requests_headers()
-            
+
             headers = {
                 "Accept": file_format,
                 "Authorization": "Bearer " + token,
-                'User-Agent': user_agent['User-Agent']
+                "User-Agent": user_agent["User-Agent"],
             }
 
             session = _get_requests_session()
@@ -115,7 +119,7 @@ def _request_insee(
 
             elif code in CODES:
                 msg = f"Error {code} - {CODES[code]}\nQuery:\n{api_url}"
-                raise requests.exceptions.RequestException(msg)
+                raise ValueError(msg)
             elif code != 200:
                 success = False
 
@@ -130,7 +134,7 @@ def _request_insee(
                     "Click on all APIs' icons one by one, select your "
                     "application, and click on Subscribe"
                 )
-                raise requests.exceptions.RequestException(msg)
+                raise ValueError(msg)
 
         else:
             # token is None

--- a/tests/localdata/test_pynsee_localdata.py
+++ b/tests/localdata/test_pynsee_localdata.py
@@ -6,7 +6,6 @@ from unittest import TestCase
 import pandas as pd
 import sys
 import unittest
-from requests.exceptions import RequestException
 
 from pynsee.localdata._get_geo_relation import _get_geo_relation
 from pynsee.localdata._get_insee_one_area import _get_insee_one_area
@@ -27,7 +26,7 @@ from pynsee.localdata.get_descending_area import get_descending_area
 
 
 class TestFunction(TestCase):
-    
+
     version = (sys.version_info[0] == 3) & (sys.version_info[1] == 8)
 
     if version:
@@ -173,11 +172,11 @@ class TestFunction(TestCase):
             )
 
         def test_get_old_city(self):
-            
+
             df = get_old_city(code="24259")
 
             self.assertTrue(isinstance(df, pd.DataFrame))
-            
+
         def test_get_geo_list_1(self):
             list_available_geo = [
                 "communes",
@@ -333,39 +332,49 @@ class TestFunction(TestCase):
             )
             test = test & isinstance(data, pd.DataFrame)
 
-            data = get_local_data(dataset_version='GEOlatestFILOlatest',
-                       variables =  'INDICS_FILO_DISP',
-                       nivgeo = 'COM',
-                       update=True,
-                       geocodes = '75056')
+            data = get_local_data(
+                dataset_version="GEOlatestFILOlatest",
+                variables="INDICS_FILO_DISP",
+                nivgeo="COM",
+                update=True,
+                geocodes="75056",
+            )
             test = test & isinstance(data, pd.DataFrame)
 
-            data = get_local_data(dataset_version='POPLEGlatest',
-                       variables =  'IND_POPLEGALES',
-                       nivgeo = 'COM',
-                       update=True,
-                       geocodes = '75056')
+            data = get_local_data(
+                dataset_version="POPLEGlatest",
+                variables="IND_POPLEGALES",
+                nivgeo="COM",
+                update=True,
+                geocodes="75056",
+            )
             test = test & isinstance(data, pd.DataFrame)
 
-            data = get_local_data(dataset_version='GEOlatestRFDlatest',
-                       variables =  'INDICS_ETATCIVIL',
-                       nivgeo = 'COM',
-                       update=True,
-                       geocodes = '75056')
+            data = get_local_data(
+                dataset_version="GEOlatestRFDlatest",
+                variables="INDICS_ETATCIVIL",
+                nivgeo="COM",
+                update=True,
+                geocodes="75056",
+            )
             test = test & isinstance(data, pd.DataFrame)
 
-            data = get_local_data(dataset_version='BDCOMlatest',
-                       variables =  'INDICS_BDCOM',
-                       nivgeo = 'COM',
-                       update=True,
-                       geocodes = '75056')
+            data = get_local_data(
+                dataset_version="BDCOMlatest",
+                variables="INDICS_BDCOM",
+                nivgeo="COM",
+                update=True,
+                geocodes="75056",
+            )
             test = test & isinstance(data, pd.DataFrame)
 
-            data = get_local_data(dataset_version='GEOlatestREElatest',
-                       variables =  'NA10_HORS_AZ-ENTR_INDIVIDUELLE',
-                       nivgeo = 'COM',
-                       update=True,
-                       geocodes = '75056')
+            data = get_local_data(
+                dataset_version="GEOlatestREElatest",
+                variables="NA10_HORS_AZ-ENTR_INDIVIDUELLE",
+                nivgeo="COM",
+                update=True,
+                geocodes="75056",
+            )
             test = test & isinstance(data, pd.DataFrame)
 
             for geo in ["DEP", "REG", "FE", "METRODOM"]:
@@ -416,10 +425,9 @@ class TestFunction(TestCase):
                 "departement", code="59", type="region", update=True
             )
             test = test & isinstance(df, pd.DataFrame)
-              
+
             df = get_ascending_area("commune", code="59350", date="2018-01-01")
             test = test & isinstance(df, pd.DataFrame)
-
 
         def test_get_local_data_latest_error(self):
             def getlocaldataTestError():
@@ -456,12 +464,14 @@ class TestFunction(TestCase):
         def test_get_area_list_2(self):
             def get_area_list_test():
                 get_area_list("a")
+
             self.assertRaises(ValueError, get_area_list_test)
 
         def test_get_area_list_3(self):
             def get_area_list_test():
                 get_area_list(area="regions", date="1900-01-01", update=True)
-            self.assertRaises(RequestException, get_area_list_test)
+
+            self.assertRaises(ValueError, get_area_list_test)
 
         def test_get_included_area(self):
             list_available_area = [
@@ -484,5 +494,6 @@ class TestFunction(TestCase):
 
             self.assertTrue(test)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/utils/test_pynsee_utils.py
+++ b/tests/utils/test_pynsee_utils.py
@@ -3,7 +3,6 @@
 
 import unittest
 from unittest import TestCase
-import requests
 
 import os
 import sys
@@ -20,7 +19,7 @@ test_SDMX = True
 
 
 class TestFunction(TestCase):
-    
+
     version = (sys.version_info[0] == 3) & (sys.version_info[1] == 9)
 
     if version:
@@ -43,9 +42,7 @@ class TestFunction(TestCase):
             def request_insee_test(sdmx_url=sdmx_url, api_url=api_url):
                 _request_insee(sdmx_url=sdmx_url, api_url=api_url)
 
-            self.assertRaises(
-                requests.exceptions.RequestException, request_insee_test
-            )
+            self.assertRaises(ValueError, request_insee_test)
 
         if test_SDMX:
 


### PR DESCRIPTION
There was a mismatch of exception types in `_request_insee.py` (both RequestException and ValueError).

This PR uniformizes all exception and update tests accordingly (I encountered one test not appropriately set while working on the PR for tests' caching).