### PR TITLE
bugfix get_geo_list

### DIFF
--- a/pynsee/localdata/get_geo_list.py
+++ b/pynsee/localdata/get_geo_list.py
@@ -94,7 +94,7 @@ def get_geo_list(geo=None, date=None, update=False, silent=False):
                     date=date,
                     type=type_geo,
                 )
-            except RequestException:
+            except (RequestException, SyntaxError):
                 df = _get_geo_relation(
                     geo="region",
                     code=list_reg[r],


### PR DESCRIPTION
Resolves the error triggered by :

```
from pynsee.localdata import get_geo_list
get_geo_list("arrondissements", "2019-01-01")
```

This was due to the new Session object not triggering an error on 404 return (not an error of the API but an empty result to the posted query).

For some reason I couldn't capture neither the ParseError from lxml nor it's lxml.etree parents (LxmlSyntaxError, LxmlError); that's why I've gone to SyntaxError which is the first built-in exception which is inherited by it...