### PR TITLE
fix/ci-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,14 @@ jobs:
           name: artifact
           path: dist
 
+      - name: Check if Release Exists
+        id: check_release
+        run: |
+          if gh release view ${{ github.ref }}; then echo "exists=true" >> $GITHUB_ENV; else echo "exists=false" >> $GITHUB_ENV; fi
+
       - name: Create GitHub Release
         id: create_release
+        if: env.exists == 'false'
         uses: actions/create-release@v1
         env:
           # This token is provided by Actions, you do not need to create your own token
@@ -57,18 +63,20 @@ jobs:
           release_name: ${{ github.ref }}
           draft: false
           prerelease: false
+
       - name: Get Asset name
         run: |
           export PKG=$(ls dist/ | grep tar)
           set -- $PKG
           echo "name=$1" >> $GITHUB_ENV
+
       - name: Upload Release Asset (sdist) to GitHub
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ steps.create_release.outputs.upload_url || "https://api.github.com/repos/${{ github.repository }}/releases/${{ github.ref }}/assets" }}
           asset_path: dist/${{ env.name }}
           asset_name: ${{ env.name }}
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,24 +46,6 @@ jobs:
           name: artifact
           path: dist
 
-      - name: Check if Release Exists
-        id: check_release
-        run: |
-          if gh release view ${{ github.ref }}; then echo "exists=true" >> $GITHUB_ENV; else echo "exists=false" >> $GITHUB_ENV; fi
-
-      - name: Create GitHub Release
-        id: create_release
-        if: env.exists == 'false'
-        uses: actions/create-release@v1
-        env:
-          # This token is provided by Actions, you do not need to create your own token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-
       - name: Get Asset name
         run: |
           export PKG=$(ls dist/ | grep tar)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url || "https://api.github.com/repos/${{ github.repository }}/releases/${{ github.ref }}/assets" }}
+          upload_url: ${{ steps.create_release.outputs.upload_url
           asset_path: dist/${{ env.name }}
           asset_name: ${{ env.name }}
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: dist/${{ env.name }}
           asset_name: ${{ env.name }}
           asset_content_type: application/zip


### PR DESCRIPTION
Should avoid creating a release which already exists.

@tfardet any idea how to test this?

Also : `actions/create-release` and `actions/upload-release-asset` are not maintained anymore , `pypa/gh-action-pypi-publish` seems outdated. As I'm never quite sure how to test CIs, I'd say we could start with fixing the limited PR as it is?