### PR TITLE
fix: requirements and release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,17 +52,6 @@ jobs:
           set -- $PKG
           echo "name=$1" >> $GITHUB_ENV
 
-      - name: Upload Release Asset (sdist) to GitHub
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/${{ env.name }}
-          asset_name: ${{ env.name }}
-          asset_content_type: application/zip
-
       - name: Upload Release Assets to PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:

--- a/pynsee/__init__.py
+++ b/pynsee/__init__.py
@@ -6,4 +6,4 @@ from pynsee.metadata import *
 from pynsee.utils import *
 from pynsee.download import *
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,2 +1,1 @@
-openpyxl
 xlrd > 2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ urllib3 >= 2.2
 shapely >= 2
 requests >= 2.32
 requests-ratelimiter >= 0.7
+openpyxl


### PR DESCRIPTION
Since #272 imports ``openpyxl``, add it to requirements.
Remove upload of content to GitHub as url is missing and this is not needed anyway.

@tgrandje merging this right away as it is not sensitive, but just pinging you so you can see what changed.