### PR TITLE
chore: remove unnecessary checks and cleanup error handling

### DIFF
--- a/pynsee/sirene/_request_sirene.py
+++ b/pynsee/sirene/_request_sirene.py
@@ -38,7 +38,7 @@ def _request_sirene(query, kind, number=1001):
     if number > number_query_limit:
         link = link + "&curseur=*"
 
-    with PynseeAPISession(url=link) as session:
+    with PynseeAPISession() as session:
         request = session.request_insee(
             api_url=link,
             file_format="application/json;charset=utf-8",
@@ -84,7 +84,7 @@ def _request_sirene(query, kind, number=1001):
                     + following_cursor
                 )
 
-                with PynseeAPISession(url=new_query) as session:
+                with PynseeAPISession() as session:
                     request_new = session.request_insee(
                         api_url=new_query,
                         file_format="application/json;charset=utf-8",

--- a/pynsee/utils/_get_credentials.py
+++ b/pynsee/utils/_get_credentials.py
@@ -3,10 +3,6 @@
 
 import json
 import logging
-import re
-
-from functools import lru_cache
-from typing import Dict
 
 from pynsee.constants import CONFIG_FILE
 
@@ -14,33 +10,18 @@ from pynsee.constants import CONFIG_FILE
 logger = logging.getLogger(__name__)
 
 
-def _get_credentials_from_configfile(url) -> Dict[str, str]:
+def _get_credentials_from_configfile() -> dict[str, str]:
     """
     Try to load credentials and proxy configuration from config file.
 
     Returns a dict containing at least an "sirene_key" entry.
     """
-    key_dict: Dict[str, str] = {}
+    key_dict: dict[str, str] = {}
 
     try:
         with open(CONFIG_FILE, "r") as f:
             key_dict = json.load(f)
-
     except FileNotFoundError:
-        if re.match(".*api-sirene.*", url):
-            # no credentials/config stored
-            _missing_credentials()
-        return key_dict
+        pass
 
     return key_dict
-
-
-@lru_cache(maxsize=None)
-def _missing_credentials() -> None:
-    logger.critical(
-        "INSEE API credentials have not been found: please try to reuse "
-        "pynsee.init_conn to save them locally.\n"
-        "Otherwise, you can still use environment variables as follow:\n\n"
-        "import os\n"
-        "os.environ['sirene_key'] = 'my_sirene_key'"
-    )

--- a/tests/macrodata/test_pynsee_macrodata.py
+++ b/tests/macrodata/test_pynsee_macrodata.py
@@ -9,7 +9,7 @@ import numpy as np
 from pandas import pandas as pd
 
 
-from pynsee.macrodata._get_insee import _get_insee, _set_date
+from pynsee.macrodata._get_insee import _set_date
 from pynsee.macrodata._get_idbank_internal_data_harmonized import (
     _get_idbank_internal_data_harmonized,
 )
@@ -36,8 +36,6 @@ from pynsee.macrodata.get_dataset import get_dataset
 from pynsee.macrodata.get_column_title import get_column_title
 from pynsee.macrodata.get_series_title import get_series_title
 from pynsee.macrodata.search_macrodata import search_macrodata
-
-from pynsee.utils._clean_insee_folder import _clean_insee_folder
 
 
 test_SDMX = True

--- a/tests/utils/test_pynsee_utils.py
+++ b/tests/utils/test_pynsee_utils.py
@@ -30,7 +30,7 @@ def test_request_insee_1():
     api_url = "dummy"
 
     with PynseeAPISession(
-        url="test", http_proxy="", https_proxy="", sirene_key=""
+        http_proxy="", https_proxy="", sirene_key=""
     ) as session:
 
         def patch_error_request_api_insee(*args, **kwargs):
@@ -89,7 +89,7 @@ def test_overriding_insee_config_and_environ():
     os.environ["DUMMY_SIRENE_KEY"] = "eggs"
     os.environ["DUMMY_HTTPS_PROXY_KEY"] = "bacon"
 
-    with PynseeAPISession(url="test") as session:
+    with PynseeAPISession() as session:
         assert session.sirene_key == "eggs"
         assert session.proxies["https"] == "bacon"
 
@@ -142,7 +142,7 @@ def test_overriding_insee_config_and_environ4():
             f,
         )
 
-    with PynseeAPISession(url="test") as session:
+    with PynseeAPISession() as session:
         assert session.sirene_key == "sausage"
         assert session.proxies["http"] is None
         assert session.proxies["https"] == "spam"


### PR DESCRIPTION
- properly raise 401 errors in SIRENE calls
- more consistent handling of errors and 404 in `get_sirene_relatives`
- remove config file check in `_get_credentials_from_configfile` (checks are done in PynseeAPISession._request_api_insee)
- cleanup error handling in PynseeAPISession._request_api_insee