### PR TITLE
Bug/fix pattern encoding for SIRENE search

### DIFF
--- a/pynsee/sirene/search_sirene.py
+++ b/pynsee/sirene/search_sirene.py
@@ -101,7 +101,7 @@ def safe_encode(field: str, val: str) -> str:
         # "ponctuation+blanc*" rule -> replace by single whitespace which
         # will be preserved anyway (and then used by the API to split
         # the query)
-        safe = "( |([" + string.punctuation + "] *))"
+        safe = "( |([" + string.punctuation + "] +))"
         val = re.sub(safe, " ", val)
     try:
         return urllib.parse.quote(val, safe=SEPARATORS[field])


### PR DESCRIPTION
Fix #286

Can anybody have a second look on the documentation's separators behaviour and my implementation of it ?

In particular concerning the `espace ponctuation+blanc*` rule which I understood as "whitespace separator" *and* "[ponctuation] plus any number of whitespace" (kind of a regex pattern with that `*` character) which doesn't make much sense (should be resumed to "whitespace OR punctuation" right ?

Note : I extracted the html table and parsed it, there should'nt be any typo in the SEPARATOR constant (I only dropped the `espace ponctuation+blanc*` rule).