### PR TITLE
allow to bypass API failure and still init a connection

### DIFF
--- a/pynsee/utils/init_connection.py
+++ b/pynsee/utils/init_connection.py
@@ -28,13 +28,19 @@ def init_conn(
     sirene_key: Optional[str] = None,
     http_proxy: Optional[str] = None,
     https_proxy: Optional[str] = None,
+    raise_if_not_ok: bool = True,
 ) -> None:
     """Save your credentials to connect to INSEE APIs, subscribe to api.insee.fr
+
+    In case of failure of an API outside your current usecase (ie. failure
+    of SIREN API server while you are actually interested in metadata) you
+    can bypass this `init_conn(raise_if_not_ok=False)`
 
     Args:
         sirene_key (str, optional): user's key for sirene API
         http_proxy (str, optional): Proxy server address, e.g. 'http://my_proxy_server:port'. Defaults to "".
         https_proxy (str, optional): Proxy server address, e.g. 'http://my_proxy_server:port'. Defaults to "".
+        raise_if_not_ok (bool, optional) : If set to True, a RequestException will automatically be raised if the response is not ok (= `status_code` >= 400). The default is True.
 
     Notes:
         Environment variables can be used instead of init_conn function
@@ -69,7 +75,9 @@ def init_conn(
         sirene_key=sirene_key, http_proxy=http_proxy, https_proxy=https_proxy
     ) as session:
         try:
-            invalid_requests = session._test_connections()
+            invalid_requests = session._test_connections(
+                raise_if_not_ok=raise_if_not_ok
+            )
         except (ValueError, requests.exceptions.RequestException):
             try:
                 os.remove(CONFIG_FILE)
@@ -80,15 +88,16 @@ def init_conn(
     if invalid_requests:
         logger.error(
             "Invalid credentials, the following APIs returned error codes, "
-            "please make sure you subscribed to them (if you need those):\n"
-            f"{invalid_requests}"
+            "please make sure you subscribed to them (if you need those):\n%s",
+            invalid_requests,
         )
     else:
         logger.info(
             "Subscription to all INSEE's APIs has been successfull\n"
             "Unless the user wants to change the key or secret, using this "
             "function is no longer needed as the credentials will be saved "
-            f"locally here:\n{CONFIG_FILE}"
+            "locally here:\n%s",
+            CONFIG_FILE,
         )
 
     if invalid_requests and ("Sirene" in invalid_requests):

--- a/pynsee/utils/requests_session.py
+++ b/pynsee/utils/requests_session.py
@@ -18,7 +18,6 @@ from pynsee.utils._get_credentials import _get_credentials_from_configfile
 from pynsee.utils._create_insee_folder import _create_insee_folder
 from pynsee.constants import SIRENE_KEY, HTTPS_PROXY_KEY, HTTP_PROXY_KEY
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -584,7 +583,9 @@ class PynseeAPISession(requests.Session):
                         "your proxy configuration "
                         f"- proxies were {self.proxies}."
                     ) from exc
-                if exc.response.status_code >= 400:
+                if exc.response.status_code == 401:
+                    _invalid_sirene_key(raise_error=raise_if_not_ok)
+                elif exc.response.status_code >= 400:
                     msg = (
                         f"Could not reach {api} at {api_url}, the server "
                         "returned {exc.response.status_code}; please get "

--- a/pynsee/utils/requests_session.py
+++ b/pynsee/utils/requests_session.py
@@ -270,7 +270,7 @@ class PynseeAPISession(requests.Session):
             info. The default is (10, 15).
         raise_if_not_ok : bool, optional
             If set to True, a RequestException will automatically be raised if
-            the response is not ok (= `status_code` < 400).
+            the response is not ok (= `status_code` >= 400).
             The default is True.
         **kwargs :
             Any other kwargs are passed directly to requests.Session.request
@@ -388,7 +388,7 @@ class PynseeAPISession(requests.Session):
             URL to query.
         raise_if_not_ok : bool, optional
             If set to True, a RequestException will automatically be raised if
-            the response is not ok (= `status_code` < 400).
+            the response is not ok (= `status_code` >= 400).
             The default is True.
 
         Raises
@@ -429,7 +429,7 @@ class PynseeAPISession(requests.Session):
             INSEE's APIs. The default is "application/xml".
         raise_if_not_ok : bool, optional
             If set to True, a RequestException will automatically be raised if
-            the response is not ok (= `status_code` < 400).
+            the response is not ok (= `status_code` >= 400).
             The default is False.
         print_msg : bool, optional
             If True, will log critical entries to warn that the call to
@@ -519,9 +519,16 @@ class PynseeAPISession(requests.Session):
         """
         return re.match(".*api-sirene.*", url) is not None
 
-    def _test_connections(self) -> dict:
+    def _test_connections(self, raise_if_not_ok: bool = True) -> dict:
         """
         Test the valid connection to each API.
+
+        Parameters
+        ----------
+        raise_if_not_ok : bool, optional
+            If set to True, a RequestException will automatically be raised if
+            the response is not ok (= `status_code` >= 400).
+            The default is True.
 
         Raises
         ------
@@ -536,6 +543,7 @@ class PynseeAPISession(requests.Session):
             Dict of {"api name": response.status_code} for invalid queries.
 
         """
+
         queries = {
             "BDM": "https://api.insee.fr/series/BDM/dataflow/FR1/all",
             "Metadata": "https://api.insee.fr/metadonnees/codes/cj/n3/5599",
@@ -567,19 +575,27 @@ class PynseeAPISession(requests.Session):
                         "your proxy configuration "
                         f"- proxies were {self.proxies}."
                     ) from exc
-                elif exc.response.status_code == 404:
-                    raise requests.exceptions.RequestException(
+                if exc.response.status_code >= 400:
+                    msg = (
                         f"Could not reach {api} at {api_url}, the server "
-                        "returned 404 (not found); please get in touch if "
-                        "the issue persists."
-                    ) from exc
+                        "returned {exc.response.status_code}; please get "
+                        f"in touch if the issue persists."
+                    )
+                    if raise_if_not_ok:
+                        raise requests.exceptions.RequestException(
+                            msg
+                        ) from exc
+                    logger.warning(msg)
 
                 invalid_requests[api] = exc.response.status_code
 
         if len(invalid_requests) == len(queries):
-            raise ValueError(
+            msg = (
                 "No API was reached. That's strange, please get in touch if "
                 "the issue persists."
             )
+            if raise_if_not_ok:
+                raise ValueError(msg)
+            logger.warning(msg)
 
         return invalid_requests

--- a/tests/utils/patches.py
+++ b/tests/utils/patches.py
@@ -96,7 +96,7 @@ def patch_test_connections(func):
     def wrapper(*args, **kwargs):
         init = PynseeAPISession._test_connections
 
-        def patched_test_connections(raise_if_not_ok=False):
+        def patched_test_connections(self, raise_if_not_ok=False):
             return {}
 
         PynseeAPISession._test_connections = patched_test_connections

--- a/tests/utils/patches.py
+++ b/tests/utils/patches.py
@@ -7,7 +7,6 @@ import requests
 import pynsee.constants
 from pynsee.utils.requests_session import PynseeAPISession
 
-
 config_file = pynsee.constants.CONFIG_FILE
 config_backup = f"{config_file}.back"
 
@@ -118,7 +117,7 @@ def patch_test_connections_and_failure_for_sirene(func):
     def wrapper(*args, **kwargs):
         init = PynseeAPISession._request_api_insee
 
-        def _request_api_insee(url, *args, **kwargs):
+        def _request_api_insee(self, url, *args, **kwargs):
             if re.match(".*api-sirene.*", url):
                 dummy_response = object()
                 dummy_response.status_code = 400

--- a/tests/utils/patches.py
+++ b/tests/utils/patches.py
@@ -95,7 +95,11 @@ def patch_test_connections(func):
 
     def wrapper(*args, **kwargs):
         init = PynseeAPISession._test_connections
-        PynseeAPISession._test_connections = lambda x: {}
+
+        def patched_test_connections(raise_if_not_ok=False):
+            return {}
+
+        PynseeAPISession._test_connections = patched_test_connections
         try:
             func(*args, **kwargs)
         except Exception:

--- a/tests/utils/test_pynsee_utils.py
+++ b/tests/utils/test_pynsee_utils.py
@@ -11,6 +11,7 @@ import pynsee.constants
 from pynsee.utils.requests_session import PynseeAPISession
 from pynsee.utils.clear_all_cache import clear_all_cache
 from pynsee.utils import init_conn
+from pynsee.metadata.get_definition import get_definition
 
 from .patches import (
     clean_os_patch,
@@ -66,7 +67,8 @@ def test_dummy_sirene_token_is_not_stored():
     with open(pynsee.constants.CONFIG_FILE, "w") as f:
         json.dump({"DUMMY_SIRENE_KEY": "spam"}, f)
 
-    init_conn(sirene_key="eggs")
+    init_conn(sirene_key="eggs", raise_if_not_ok=False)
+    get_definition(ids=["c1020", "c1601"])
 
     with open(pynsee.constants.CONFIG_FILE, "r") as f:
         assert json.load(f)["DUMMY_SIRENE_KEY"] == "spam"


### PR DESCRIPTION
https://github.com/InseeFrLab/pynsee/issues/290

Allow to bypass failure on API A (because of server errors) when querying API B.